### PR TITLE
Fix python error on tostring()

### DIFF
--- a/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
+++ b/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
@@ -463,12 +463,12 @@ class GenFdsGlobalVariable:
                     GenFdsGlobalVariable.SecCmdList.append(' '.join(Cmd).strip())
             else:
                 SectionData = array('B', [0, 0, 0, 0])
-                SectionData.fromstring(Ui.encode("utf_16_le"))
+                SectionData.frombytes(Ui.encode("utf_16_le"))
                 SectionData.append(0)
                 SectionData.append(0)
                 Len = len(SectionData)
                 GenFdsGlobalVariable.SectionHeader.pack_into(SectionData, 0, Len & 0xff, (Len >> 8) & 0xff, (Len >> 16) & 0xff, 0x15)
-                SaveFileOnChange(Output, SectionData.tostring())
+                SaveFileOnChange(Output, SectionData.tobytes())
 
         elif Ver:
             Cmd += ("-n", Ver)


### PR DESCRIPTION
I couldn't compile the uefipayloadpkg because of a python error. Phython has replaced tostring with tobytes and the fromXXX as well since version 3.2


I was then able to build. Bios still rungs